### PR TITLE
Re-order Filters to Fix Issue for listToDos()

### DIFF
--- a/server/src/main/java/umm3601/todos/ToDosDatabase.java
+++ b/server/src/main/java/umm3601/todos/ToDosDatabase.java
@@ -69,17 +69,6 @@ import io.javalin.http.BadRequestResponse;
         }
       }
 
-      //Limit request
-      if (queryParams.containsKey("limit")) {
-        String limitParam = queryParams.get("limit").get(0);
-        try {
-          int targetLimit = Integer.parseInt(limitParam);
-          filteredToDos = filterToDosByLimit(filteredToDos, targetLimit);
-        } catch (NumberFormatException e) {
-          throw new BadRequestResponse("Specified limit '" + limitParam + "' can't be parsed to an integer");
-        }
-      }
-
       //Filter body is defined
       if (queryParams.containsKey("contains")) {
         String targetBody = queryParams.get("contains").get(0);
@@ -103,6 +92,17 @@ import io.javalin.http.BadRequestResponse;
       if (queryParams.containsKey("orderBy")) {
         String targetOrderBy = queryParams.get("orderBy").get(0);
         filteredToDos = sortToDosByOrderBy(filteredToDos, targetOrderBy);
+      }
+
+      //Limit request
+      if (queryParams.containsKey("limit")) {
+        String limitParam = queryParams.get("limit").get(0);
+        try {
+          int targetLimit = Integer.parseInt(limitParam);
+          filteredToDos = filterToDosByLimit(filteredToDos, targetLimit);
+        } catch (NumberFormatException e) {
+          throw new BadRequestResponse("Specified limit '" + limitParam + "' can't be parsed to an integer");
+        }
       }
 
       return filteredToDos;


### PR DESCRIPTION
Move limit filter to the last place in the order for listToDos() to fix the issue when clients ask for arbitrary combinations of these filters: owner, status, limit.